### PR TITLE
feat: add new UDT model which uses only one cell per wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,20 @@ The following code fulfills this step:
 [20] pry(main)> alice_token1.get_balance
 => 12345
 ```
+
+### User Defined Token which uses only one cell per wallet:
+
+```bash
+[1] pry(main)> admin = Ckb::Wallet.from_hex(Ckb::Api.new, "e79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3")
+[2] pry(main)> alice = Ckb::Wallet.from_hex(Ckb::Api.new, "76e853efa8245389e33f6fe49dcbd359eb56be2f6c3594e12521d2a806d32156")
+[3] pry(main)> token_info2 = admin.created_token_info("Token 2")
+[4] pry(main)> admin_cell_token2 = admin.udt_cell_wallet(token_info2)
+[5] pry(main)> alice_cell_token2 = alice.udt_cell_wallet(token_info2)
+[6] pry(main)> admin.create_udt_token(10000, "Token 2", 10000000, cell_wallet: true)
+[7] pry(main)> alice.create_udt_cell_wallet_cell(3000, token_info2)
+[8] pry(main)> admin_cell_token2.send_tokens(12345, alice_cell_token2)
+[9] pry(main)> admin_cell_token2.get_balance
+[10] pry(main)> alice_cell_token2.get_balance
+```
+
+NOTE: While it might be possible to mix the 2 ways of using user defined token above in one token, we don't really recommend that since it could be the source of a lot of confusions.

--- a/README.md
+++ b/README.md
@@ -219,10 +219,10 @@ The following code fulfills this step:
 [1] pry(main)> admin = Ckb::Wallet.from_hex(Ckb::Api.new, "e79f3207ea4980b7fed79956d5934249ceac4751a4fae01a0f7c4a96884bc4e3")
 [2] pry(main)> alice = Ckb::Wallet.from_hex(Ckb::Api.new, "76e853efa8245389e33f6fe49dcbd359eb56be2f6c3594e12521d2a806d32156")
 [3] pry(main)> token_info2 = admin.created_token_info("Token 2")
-[4] pry(main)> admin_cell_token2 = admin.udt_cell_wallet(token_info2)
-[5] pry(main)> alice_cell_token2 = alice.udt_cell_wallet(token_info2)
-[6] pry(main)> admin.create_udt_token(10000, "Token 2", 10000000, cell_wallet: true)
-[7] pry(main)> alice.create_udt_cell_wallet_cell(3000, token_info2)
+[4] pry(main)> admin_cell_token2 = admin.udt_account_wallet(token_info2)
+[5] pry(main)> alice_cell_token2 = alice.udt_account_wallet(token_info2)
+[6] pry(main)> admin.create_udt_token(10000, "Token 2", 10000000, account_wallet: true)
+[7] pry(main)> alice.create_udt_account_wallet_cell(3000, token_info2)
 [8] pry(main)> admin_cell_token2.send_tokens(12345, alice_cell_token2)
 [9] pry(main)> admin_cell_token2.get_balance
 [10] pry(main)> alice_cell_token2.get_balance

--- a/contracts/udt/unlock.rb
+++ b/contracts/udt/unlock.rb
@@ -11,7 +11,7 @@
 # for SIGHASH_SINGLE, it stores an integer denoting the index of output to be
 # signed; for SIGHASH_MULTIPLE, it stores a string of `,` separated array denoting
 # outputs to sign
-if ARGV.length < 4
+if ARGV.length != 4 && ARGV.length != 5
   raise "Wrong number of arguments!"
 end
 
@@ -31,10 +31,7 @@ end
 tx = CKB.load_tx
 sha3 = Sha3.new
 
-ARGV.drop(3).each do |argument|
-  sha3.update(argument)
-end
-
+sha3.update(ARGV[3])
 sighash_type = ARGV[3].to_i
 
 if sighash_type & SIGHASH_ANYONECANPAY != 0

--- a/contracts/udt/unlock_single_cell.rb
+++ b/contracts/udt/unlock_single_cell.rb
@@ -1,0 +1,132 @@
+# This contract needs 2 signed arguments:
+# 0. token name, this is here so we can have different lock hash for
+# different token for ease of querying. In the actual contract this is
+# not used.
+# 1. pubkey, used to identify token owner
+# This contracts also 3 optional unsigned arguments:
+# 2. signature, signature used to present ownership
+# 3. type, SIGHASH type
+# 4. output(s), this is only used for SIGHASH_SINGLE and SIGHASH_MULTIPLE types,
+# for SIGHASH_SINGLE, it stores an integer denoting the index of output to be
+# signed; for SIGHASH_MULTIPLE, it stores a string of `,` separated array denoting
+# outputs to sign
+# If they exist, we will do the proper signature verification way, if not
+# we will check for lock hash, and only accept transactions that have more
+# tokens in the output cell than input cell so as to allow receiving tokens.
+if ARGV.length != 2 && ARGV.length != 4 && ARGV.length != 5
+  raise "Wrong number of arguments!"
+end
+
+SIGHASH_ALL = 0x1
+SIGHASH_NONE = 0x2
+SIGHASH_SINGLE = 0x3
+SIGHASH_MULTIPLE = 0x4
+SIGHASH_ANYONECANPAY = 0x80
+
+def hex_to_bin(s)
+  if s.start_with?("0x")
+    s = s[2..-1]
+  end
+  s.each_char.each_slice(2).map(&:join).map(&:hex).map(&:chr).join
+end
+
+tx = CKB.load_tx
+sha3 = Sha3.new
+
+if ARGV.length >= 4
+  sha3.update(ARGV[3])
+  sighash_type = ARGV[3].to_i
+
+  if sighash_type & SIGHASH_ANYONECANPAY != 0
+    # Only hash current input
+    outpoint = CKB.load_input_out_point(0, CKB::Source::CURRENT)
+    sha3.update(outpoint["hash"])
+    sha3.update(outpoint["index"].to_s)
+    sha3.update(CKB::CellField.new(CKB::Source::CURRENT, 0, CKB::CellField::LOCK_HASH).readall)
+  else
+    # Hash all inputs
+    tx["inputs"].each_with_index do |input, i|
+      sha3.update(input["hash"])
+      sha3.update(input["index"].to_s)
+      sha3.update(CKB.load_script_hash(i, CKB::Source::INPUT, CKB::Category::LOCK))
+    end
+  end
+
+  case sighash_type & (~SIGHASH_ANYONECANPAY)
+  when SIGHASH_ALL
+    tx["outputs"].each_with_index do |output, i|
+      sha3.update(output["capacity"].to_s)
+      sha3.update(output["lock"])
+      if hash = CKB.load_script_hash(i, CKB::Source::OUTPUT, CKB::Category::CONTRACT)
+        sha3.update(hash)
+      end
+    end
+  when SIGHASH_SINGLE
+    raise "Not enough arguments" unless ARGV[4]
+    output_index = ARGV[4].to_i
+    output = tx["outputs"][output_index]
+    sha3.update(output["capacity"].to_s)
+    sha3.update(output["lock"])
+    if hash = CKB.load_script_hash(output_index, CKB::Source::OUTPUT, CKB::Category::CONTRACT)
+      sha3.update(hash)
+    end
+  when SIGHASH_MULTIPLE
+    raise "Not enough arguments" unless ARGV[4]
+    ARGV[4].split(",").each do |output_index|
+      output_index = output_index.to_i
+      output = tx["outputs"][output_index]
+      sha3.update(output["capacity"].to_s)
+      sha3.update(output["lock"])
+      if hash = CKB.load_script_hash(output_index, CKB::Source::OUTPUT, CKB::Category::CONTRACT)
+        sha3.update(hash)
+      end
+    end
+  end
+  hash = sha3.final
+
+  pubkey = ARGV[1]
+  signature = ARGV[2]
+
+  unless Secp256k1.verify(hex_to_bin(pubkey), hex_to_bin(signature), hash)
+    raise "Signature verification error!"
+  end
+else
+  # In case a signature is missing, we will only accept the tx when:
+  # * The tx only has one input matching current lock hash and contract hash
+  # * The tx only has one output matching current lock hash and contract hash
+  # * The matched output has the same amount of capacity but more tokens
+  # than the input
+  # This would allow a sender to send tokens to a receiver in one step
+  # without needing work from the receiver side.
+  current_lock_hash = CKB.load_script_hash(0, CKB::Source::CURRENT, CKB::Category::LOCK)
+  current_contract_hash = CKB.load_script_hash(0, CKB::Source::CURRENT, CKB::Category::CONTRACT)
+  unless current_contract_hash
+    raise "Contract is not available in current cell!"
+  end
+  input_matches = tx["inputs"].length.times.select do |i|
+    CKB.load_script_hash(i, CKB::Source::INPUT, CKB::Category::LOCK) == current_lock_hash &&
+      CKB.load_script_hash(i, CKB::Source::INPUT, CKB::Category::CONTRACT) == current_contract_hash
+  end
+  if input_matches.length > 1
+    raise "Invalid input cell number!"
+  end
+  output_matches = tx["outputs"].length.times.select do |i|
+    CKB.load_script_hash(i, CKB::Source::OUTPUT, CKB::Category::LOCK) == current_lock_hash &&
+      CKB.load_script_hash(i, CKB::Source::OUTPUT, CKB::Category::CONTRACT) == current_contract_hash
+  end
+  if output_matches.length > 1
+    raise "Invalid output cell number!"
+  end
+  input_index = input_matches[0]
+  output_index = output_matches[0]
+  input_capacity = CKB::CellField.new(CKB::Source::INPUT, input_index, CKB::CellField::CAPACITY).read(0, 8).unpack("Q<")[0]
+  output_capacity = CKB::CellField.new(CKB::Source::OUTPUT, output_index, CKB::CellField::CAPACITY).read(0, 8).unpack("Q<")[0]
+  if input_capacity != output_capacity
+    raise "Capacity cannot be tweaked!"
+  end
+  input_amount = CKB::CellField.new(CKB::Source::INPUT, input_index, CKB::CellField::DATA).read(0, 8).unpack("Q<")[0]
+  output_amount = CKB::CellField.new(CKB::Source::OUTPUT, output_index, CKB::CellField::DATA).read(0, 8).unpack("Q<")[0]
+  if output_amount <= input_amount
+    raise "You can only deposit tokens here!"
+  end
+end

--- a/lib/ckb/udt_wallet.rb
+++ b/lib/ckb/udt_wallet.rb
@@ -168,7 +168,7 @@ module Ckb
       api.send_transaction(tx)
     end
 
-    # Merge multiple UDT cells into one so we can use UdtCellWallet
+    # Merge multiple UDT cells into one so we can use UdtAccountWallet
     def merge_cells
       inputs = []
       total_amount = 0
@@ -292,7 +292,7 @@ module Ckb
     end
   end
 
-  class UdtCellWallet < UdtBaseWallet
+  class UdtAccountWallet < UdtBaseWallet
     def get_balance
       fetch_cell[:amount]
     end

--- a/lib/ckb/udt_wallet.rb
+++ b/lib/ckb/udt_wallet.rb
@@ -6,6 +6,7 @@ require "securerandom"
 
 module Ckb
   UNLOCK_SCRIPT = File.read(File.expand_path("../../../contracts/udt/unlock.rb", __FILE__))
+  UNLOCK_SINGLE_CELL_SCRIPT = File.read(File.expand_path("../../../contracts/udt/unlock_single_cell.rb", __FILE__))
   CONTRACT_SCRIPT = File.read(File.expand_path("../../../contracts/udt/contract.rb", __FILE__))
 
   class TokenInfo
@@ -18,7 +19,7 @@ module Ckb
     end
   end
 
-  class UdtWallet
+  class UdtBaseWallet
     attr_reader :api
     attr_reader :privkey
     attr_reader :token_info
@@ -45,6 +46,34 @@ module Ckb
       mruby_unlock_type_hash
     end
 
+    def mruby_contract_script_json_object
+      {
+        version: 0,
+        reference: api.mruby_cell_hash,
+        signed_args: [
+          CONTRACT_SCRIPT,
+          token_info.name,
+          token_info.pubkey
+        ]
+      }
+    end
+
+    def mruby_unlock_type_hash
+      Ckb::Utils.json_script_to_type_hash(mruby_unlock_script_json_object)
+    end
+
+    def mruby_contract_type_hash
+      Ckb::Utils.json_script_to_type_hash(mruby_contract_script_json_object)
+    end
+
+    def get_transaction(hash_hex)
+      api.get_transaction(hash_hex)
+    end
+
+    def pubkey_bin
+      Ckb::Utils.extract_pubkey_bin(privkey)
+    end
+
     def get_unspent_cells
       hash = mruby_unlock_type_hash
       to = api.get_tip_number
@@ -53,7 +82,9 @@ module Ckb
       while current_from <= to
         current_to = [current_from + 100, to].min
         cells = api.get_cells_by_type_hash(hash, current_from, current_to)
-        cells_with_data = cells.map do |cell|
+        cells_with_data = cells.select do |cell|
+          cell[:lock] == address
+        end.map do |cell|
           tx = get_transaction(cell[:outpoint][:hash])
           amount = tx[:transaction][:outputs][cell[:outpoint][:index]][:data].pack("c*").unpack("Q<")[0]
           cell.merge(amount: amount)
@@ -63,34 +94,11 @@ module Ckb
       end
       results
     end
+  end
 
+  class UdtWallet < UdtBaseWallet
     def get_balance
       get_unspent_cells.map { |c| c[:amount] }.reduce(0, &:+)
-    end
-
-    def generate_output(udt_address, amount, capacity)
-      output = {
-        capacity: capacity,
-        data: [amount].pack("Q<"),
-        lock: udt_address,
-        contract: {
-          version: 0,
-          args: [],
-          reference: api.mruby_cell_hash,
-          signed_args: [
-            Ckb::CONTRACT_SCRIPT,
-            token_info.name,
-            token_info.pubkey
-          ]
-        }
-      }
-
-      min_capacity = calculate_cell_min_capacity(output)
-      if capacity < min_capacity
-        raise "Capacity is not enough to hold the whole cell, minimal capacity: #{min_capacity}"
-      end
-
-      output
     end
 
     # Generate a partial tx which provides CKB coins in exchange for UDT tokens.
@@ -160,6 +168,49 @@ module Ckb
       api.send_transaction(tx)
     end
 
+    # Merge multiple UDT cells into one so we can use UdtCellWallet
+    def merge_cells
+      inputs = []
+      total_amount = 0
+      total_capacity = 0
+      get_unspent_cells.each do |cell|
+        input = {
+          previous_output: {
+            hash: cell[:outpoint][:hash],
+            index: cell[:outpoint][:index]
+          },
+          unlock: mruby_unlock_script_json_object
+        }
+        inputs << input
+        input_capacity += cell[:capacity]
+        input_amount += cell[:amount]
+      end
+      outputs = [
+        {
+          capacity: total_capacity,
+          data: [total_amount].pack("Q<"),
+          lock: wallet.udt_cell_wallet(token_info).address,
+          contract: {
+            version: 0,
+            args: [mruby_contract_type_hash],
+            reference: api.mruby_cell_hash,
+            signed_args: [
+              Ckb::CONTRACT_SCRIPT,
+              token_info.name,
+              token_info.pubkey
+            ]
+          }
+        }
+      ]
+      tx = {
+        version: 0,
+        deps: [api.mruby_script_outpoint],
+        inputs: Ckb::Utils.sign_sighash_all_inputs(inputs, outputs, privkey),
+        outputs: outputs
+      }
+      api.send_transaction(tx)
+    end
+
     def mruby_unlock_script_json_object
       {
         version: 0,
@@ -170,30 +221,6 @@ module Ckb
           Ckb::Utils.bin_to_hex(pubkey_bin)
         ]
       }
-    end
-
-    def mruby_contract_script_json_object
-      {
-        version: 0,
-        reference: api.mruby_cell_hash,
-        signed_args: [
-          CONTRACT_SCRIPT,
-          token_info.name,
-          token_info.pubkey
-        ]
-      }
-    end
-
-    def mruby_unlock_type_hash
-      Ckb::Utils.json_script_to_type_hash(mruby_unlock_script_json_object)
-    end
-
-    def mruby_contract_type_hash
-      Ckb::Utils.json_script_to_type_hash(mruby_contract_script_json_object)
-    end
-
-    def get_transaction(hash_hex)
-      api.get_transaction(hash_hex)
     end
 
     private
@@ -211,6 +238,31 @@ module Ckb
         capacity += (contract[:signed_args] || []).map { |arg| arg.size }.reduce(&:+)
       end
       capacity
+    end
+
+    def generate_output(udt_address, amount, capacity)
+      output = {
+        capacity: capacity,
+        data: [amount].pack("Q<"),
+        lock: udt_address,
+        contract: {
+          version: 0,
+          args: [],
+          reference: api.mruby_cell_hash,
+          signed_args: [
+            Ckb::CONTRACT_SCRIPT,
+            token_info.name,
+            token_info.pubkey
+          ]
+        }
+      }
+
+      min_capacity = Ckb::Utils.calculate_cell_min_capacity(output)
+      if capacity < min_capacity
+        raise "Capacity is not enough to hold the whole cell, minimal capacity: #{min_capacity}"
+      end
+
+      output
     end
 
     def gather_inputs(amount)
@@ -238,17 +290,111 @@ module Ckb
       OpenStruct.new(inputs: inputs, amounts: input_amounts,
                      capacities: input_capacities)
     end
+  end
 
-    def pubkey_bin
-      Ckb::Utils.extract_pubkey_bin(privkey)
+  class UdtCellWallet < UdtBaseWallet
+    def get_balance
+      fetch_cell[:amount]
     end
 
-    def self.random(api)
-      self.new(api, SecureRandom.bytes(32))
+    def latest_outpoint
+      fetch_cell[:outpoint]
     end
 
-    def self.from_hex(api, privkey_hex)
-      self.new(api, Ckb::Utils.hex_to_bin(privkey_hex))
+    def created?
+      get_unspent_cells.length > 0
+    end
+
+    def fetch_cell
+      cells = get_unspent_cells
+      case cells.length
+      when 0
+        raise "Please create udt cell wallet first!"
+      when 1
+        cells[0]
+      else
+        raise "There's more than one cell for this UDT! You can use merge_cells in UdtWallet to merge them into one"
+      end
+    end
+
+    # Generates a partial tx that provides some UDTs for other user, who
+    # can only accept the exact amount provided here but no more
+    def send_tokens(amount, target_wallet)
+      cell = fetch_cell
+      target_cell = target_wallet.fetch_cell
+      if amount > cell[:amount]
+        raise "Do not have that much amount!"
+      end
+      inputs = [
+        {
+          previous_output: {
+            hash: cell[:outpoint][:hash],
+            index: cell[:outpoint][:index]
+          },
+          unlock: mruby_unlock_script_json_object
+        }
+      ]
+      outputs = [
+        {
+          capacity: cell[:capacity],
+          data: [cell[:amount] - amount].pack("Q<"),
+          lock: address,
+          contract: {
+            version: 0,
+            args: [],
+            reference: api.mruby_cell_hash,
+            signed_args: [
+              Ckb::CONTRACT_SCRIPT,
+              token_info.name,
+              token_info.pubkey
+            ]
+          }
+        },
+        {
+          capacity: target_cell[:capacity],
+          data: [target_cell[:amount] + amount].pack("Q<"),
+          lock: target_cell[:lock],
+          contract: {
+            version: 0,
+            args: [],
+            reference: api.mruby_cell_hash,
+            signed_args: [
+              Ckb::CONTRACT_SCRIPT,
+              token_info.name,
+              token_info.pubkey
+            ]
+          }
+        }
+      ]
+      signed_inputs = Ckb::Utils.sign_sighash_all_anyonecanpay_inputs(inputs, outputs, privkey)
+      # This doesn't need a signature
+      target_input = {
+        previous_output: {
+          hash: target_cell[:outpoint][:hash],
+          index: target_cell[:outpoint][:index]
+        },
+        unlock: target_wallet.mruby_unlock_script_json_object,
+      }
+      tx = {
+        version: 0,
+        deps: [api.mruby_script_outpoint],
+        inputs: signed_inputs + [target_input],
+        outputs: outputs
+      }
+      api.send_transaction(tx)
+    end
+
+    def mruby_unlock_script_json_object
+      {
+        version: 0,
+        reference: api.mruby_cell_hash,
+        signed_args: [
+          UNLOCK_SINGLE_CELL_SCRIPT,
+          token_info.name,
+          Ckb::Utils.bin_to_hex(pubkey_bin)
+        ],
+        args: []
+      }
     end
   end
 end

--- a/lib/ckb/utils.rb
+++ b/lib/ckb/utils.rb
@@ -116,6 +116,22 @@ module Ckb
       end
     end
 
+    def self.calculate_cell_min_capacity(output)
+      capacity = 8 + output[:data].size + Ckb::Utils.hex_to_bin(output[:lock]).size
+      if contract = output[:contract]
+        capacity += 1
+        capacity += (contract[:args] || []).map { |arg| arg.size }.reduce(0, &:+)
+        if contract[:reference]
+          capacity += Ckb::Utils.hex_to_bin(contract[:reference]).size
+        end
+        if contract[:binary]
+          capacity += contract[:binary].size
+        end
+        capacity += (contract[:signed_args] || []).map { |arg| arg.size }.reduce(&:+)
+      end
+      capacity
+    end
+
     # In Ruby, bytes are represented using String, but Rust uses Vec<u8>
     # to represent bytes, which needs raw array in JSON part, hence we
     # have to do type conversions here.

--- a/lib/ckb/wallet.rb
+++ b/lib/ckb/wallet.rb
@@ -106,15 +106,68 @@ module Ckb
       TokenInfo.new(token_name, Ckb::Utils.bin_to_hex(pubkey_bin))
     end
 
-    def create_udt_token(capacity, token_name, tokens)
+    # Create a new cell for storing an existing user defined token, you can
+    # think this as an ethereum account for a user defined token
+    def create_udt_cell_wallet_cell(capacity, token_info)
+      if udt_cell_wallet(token_info).created?
+        raise "Cell is already created!"
+      end
+      cell = {
+        capacity: capacity,
+        data: [0].pack("Q<"),
+        lock: udt_cell_wallet(token_info).address,
+        contract: {
+          version: 0,
+          args: [],
+          reference: api.mruby_cell_hash,
+          signed_args: [
+            Ckb::CONTRACT_SCRIPT,
+            token_info.name,
+            token_info.pubkey
+          ]
+        }
+      }
+      needed_capacity = Ckb::Utils.calculate_cell_min_capacity(cell)
+      if capacity < needed_capacity
+        raise "Not enough capacity for account cell, needed: #{needed_capacity}"
+      end
+
+      i = gather_inputs(capacity, MIN_UDT_CELL_CAPACITY)
+      input_capacities = i.capacities
+
+      outputs = [cell]
+      if input_capacities > capacity
+        outputs << {
+          capacity: input_capacities - capacity,
+          data: [],
+          lock: self.address
+        }
+      end
+      tx = {
+        version: 0,
+        deps: [api.mruby_script_outpoint],
+        inputs: Ckb::Utils.sign_sighash_all_inputs(i.inputs, outputs, privkey),
+        outputs: outputs
+      }
+      hash = api.send_transaction(tx)
+      # This is in fact an OutPoint here
+      {
+        hash: hash,
+        index: 0
+      }
+    end
+
+    # Issue a new user defined token using current wallet as token superuser
+    def create_udt_token(capacity, token_name, tokens, cell_wallet: false)
       token_info = created_token_info(token_name)
+      wallet = cell_wallet ? udt_cell_wallet(token_info) : udt_wallet(token_info)
 
       i = gather_inputs(capacity, MIN_UDT_CELL_CAPACITY)
       input_capacities = i.capacities
 
       data = [tokens].pack("Q<")
       s = SHA3::Digest::SHA256.new
-      s.update(Ckb::Utils.hex_to_bin(udt_wallet(token_info).mruby_contract_type_hash))
+      s.update(Ckb::Utils.hex_to_bin(wallet.mruby_contract_type_hash))
       s.update(data)
       key = Secp256k1::PrivateKey.new(privkey: privkey)
       signature = key.ecdsa_serialize(key.ecdsa_sign(s.digest, raw: true))
@@ -124,7 +177,7 @@ module Ckb
         {
           capacity: capacity,
           data: data,
-          lock: udt_wallet(token_info).address,
+          lock: wallet.address,
           contract: {
             version: 0,
             args: [
@@ -158,6 +211,10 @@ module Ckb
 
     def udt_wallet(token_info)
       Ckb::UdtWallet.new(api, privkey, token_info)
+    end
+
+    def udt_cell_wallet(token_info)
+      Ckb::UdtCellWallet.new(api, privkey, token_info)
     end
 
     private

--- a/lib/ckb/wallet.rb
+++ b/lib/ckb/wallet.rb
@@ -108,14 +108,14 @@ module Ckb
 
     # Create a new cell for storing an existing user defined token, you can
     # think this as an ethereum account for a user defined token
-    def create_udt_cell_wallet_cell(capacity, token_info)
-      if udt_cell_wallet(token_info).created?
+    def create_udt_account_wallet_cell(capacity, token_info)
+      if udt_account_wallet(token_info).created?
         raise "Cell is already created!"
       end
       cell = {
         capacity: capacity,
         data: [0].pack("Q<"),
-        lock: udt_cell_wallet(token_info).address,
+        lock: udt_account_wallet(token_info).address,
         contract: {
           version: 0,
           args: [],
@@ -158,9 +158,9 @@ module Ckb
     end
 
     # Issue a new user defined token using current wallet as token superuser
-    def create_udt_token(capacity, token_name, tokens, cell_wallet: false)
+    def create_udt_token(capacity, token_name, tokens, account_wallet: false)
       token_info = created_token_info(token_name)
-      wallet = cell_wallet ? udt_cell_wallet(token_info) : udt_wallet(token_info)
+      wallet = account_wallet ? udt_account_wallet(token_info) : udt_wallet(token_info)
 
       i = gather_inputs(capacity, MIN_UDT_CELL_CAPACITY)
       input_capacities = i.capacities
@@ -213,8 +213,8 @@ module Ckb
       Ckb::UdtWallet.new(api, privkey, token_info)
     end
 
-    def udt_cell_wallet(token_info)
-      Ckb::UdtCellWallet.new(api, privkey, token_info)
+    def udt_account_wallet(token_info)
+      Ckb::UdtAccountWallet.new(api, privkey, token_info)
     end
 
     private


### PR DESCRIPTION
Previously, our UDT model works on a set of cells in one account(like bitcoin model), this PR adds a new mode where we can use only one cell to represent a single account, which is like ETH model.

One novelty to this model is that it demonstrates how one can temporarily transfer his/her cell to a different user for valid manipulation.