### PR TITLE
Rename outpoint to out_point

### DIFF
--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -28,7 +28,7 @@ module Ckb
     end
 
     # Returns a default secp256k1-sha3 input unlock contract included in CKB
-    def basic_verify_script_outpoint
+    def basic_verify_script_out_point
       OpenStruct.new(hash_value: Ckb::Utils.hex_to_bin(genesis_block[:transactions][0][:hash]),
                      index: 0)
     end
@@ -38,7 +38,7 @@ module Ckb
     end
 
     # Returns a contract that could load Ruby source code in CKB
-    def mruby_script_outpoint
+    def mruby_script_out_point
       {
         hash: genesis_block[:transactions][0][:hash],
         index: 2
@@ -79,13 +79,13 @@ module Ckb
       rpc_request("get_transaction", params: [tx_hash_hex])[:result]
     end
 
-    def get_current_cell(outpoint)
+    def get_current_cell(out_point)
       # This way we can detect type errors early instead of weird RPC errors
-      normalized_outpoint = {
-        hash: outpoint[:hash],
-        index: outpoint[:index]
+      normalized_out_point = {
+        hash: out_point[:hash],
+        index: out_point[:index]
       }
-      rpc_request("get_current_cell", params: [normalized_outpoint])[:result]
+      rpc_request("get_current_cell", params: [normalized_out_point])[:result]
     end
 
     def send_transaction(transaction)

--- a/lib/ckb/udt_wallet.rb
+++ b/lib/ckb/udt_wallet.rb
@@ -85,8 +85,8 @@ module Ckb
         cells_with_data = cells.select do |cell|
           cell[:lock] == address
         end.map do |cell|
-          tx = get_transaction(cell[:outpoint][:hash])
-          amount = tx[:transaction][:outputs][cell[:outpoint][:index]][:data].pack("c*").unpack("Q<")[0]
+          tx = get_transaction(cell[:out_point][:hash])
+          amount = tx[:transaction][:outputs][cell[:out_point][:index]][:data].pack("c*").unpack("Q<")[0]
           cell.merge(amount: amount)
         end
         results.concat(cells_with_data)
@@ -176,8 +176,8 @@ module Ckb
       get_unspent_cells.each do |cell|
         input = {
           previous_output: {
-            hash: cell[:outpoint][:hash],
-            index: cell[:outpoint][:index]
+            hash: cell[:out_point][:hash],
+            index: cell[:out_point][:index]
           },
           unlock: mruby_unlock_script_json_object
         }
@@ -272,8 +272,8 @@ module Ckb
       get_unspent_cells.each do |cell|
         input = {
           previous_output: {
-            hash: cell[:outpoint][:hash],
-            index: cell[:outpoint][:index]
+            hash: cell[:out_point][:hash],
+            index: cell[:out_point][:index]
           },
           unlock: mruby_unlock_script_json_object
         }
@@ -298,7 +298,7 @@ module Ckb
     end
 
     def latest_outpoint
-      fetch_cell[:outpoint]
+      fetch_cell[:out_point]
     end
 
     def created?
@@ -328,8 +328,8 @@ module Ckb
       inputs = [
         {
           previous_output: {
-            hash: cell[:outpoint][:hash],
-            index: cell[:outpoint][:index]
+            hash: cell[:out_point][:hash],
+            index: cell[:out_point][:index]
           },
           unlock: mruby_unlock_script_json_object
         }
@@ -370,8 +370,8 @@ module Ckb
       # This doesn't need a signature
       target_input = {
         previous_output: {
-          hash: target_cell[:outpoint][:hash],
-          index: target_cell[:outpoint][:index]
+          hash: target_cell[:out_point][:hash],
+          index: target_cell[:out_point][:index]
         },
         unlock: target_wallet.mruby_unlock_script_json_object,
       }

--- a/lib/ckb/udt_wallet.rb
+++ b/lib/ckb/udt_wallet.rb
@@ -161,7 +161,7 @@ module Ckb
       self_inputs = Ckb::Utils.sign_sighash_all_anyonecanpay_inputs(i.inputs, outputs, privkey)
       tx = {
         version: 0,
-        deps: [api.mruby_script_outpoint],
+        deps: [api.mruby_script_out_point],
         inputs: inputs + self_inputs,
         outputs: outputs
       }
@@ -204,7 +204,7 @@ module Ckb
       ]
       tx = {
         version: 0,
-        deps: [api.mruby_script_outpoint],
+        deps: [api.mruby_script_out_point],
         inputs: Ckb::Utils.sign_sighash_all_inputs(inputs, outputs, privkey),
         outputs: outputs
       }
@@ -297,7 +297,7 @@ module Ckb
       fetch_cell[:amount]
     end
 
-    def latest_outpoint
+    def latest_out_point
       fetch_cell[:out_point]
     end
 
@@ -377,7 +377,7 @@ module Ckb
       }
       tx = {
         version: 0,
-        deps: [api.mruby_script_outpoint],
+        deps: [api.mruby_script_out_point],
         inputs: signed_inputs + [target_input],
         outputs: outputs
       }

--- a/lib/ckb/wallet.rb
+++ b/lib/ckb/wallet.rb
@@ -62,7 +62,7 @@ module Ckb
       end
       {
         version: 0,
-        deps: [api.mruby_script_outpoint],
+        deps: [api.mruby_script_out_point],
         inputs: Ckb::Utils.sign_sighash_all_inputs(i.inputs, outputs, privkey),
         outputs: outputs
       }
@@ -96,7 +96,7 @@ module Ckb
 
       {
         version: 0,
-        deps: [api.mruby_script_outpoint],
+        deps: [api.mruby_script_out_point],
         inputs: Ckb::Utils.sign_sighash_multiple_anyonecanpay_inputs(i.inputs, outputs, privkey),
         outputs: outputs
       }
@@ -145,7 +145,7 @@ module Ckb
       end
       tx = {
         version: 0,
-        deps: [api.mruby_script_outpoint],
+        deps: [api.mruby_script_out_point],
         inputs: Ckb::Utils.sign_sighash_all_inputs(i.inputs, outputs, privkey),
         outputs: outputs
       }
@@ -201,7 +201,7 @@ module Ckb
       end
       tx = {
         version: 0,
-        deps: [api.mruby_script_outpoint],
+        deps: [api.mruby_script_out_point],
         inputs: Ckb::Utils.sign_sighash_all_inputs(i.inputs, outputs, privkey),
         outputs: outputs
       }

--- a/lib/ckb/wallet.rb
+++ b/lib/ckb/wallet.rb
@@ -228,8 +228,8 @@ module Ckb
       get_unspent_cells.each do |cell|
         input = {
           previous_output: {
-            hash: cell[:outpoint][:hash],
-            index: cell[:outpoint][:index]
+            hash: cell[:out_point][:hash],
+            index: cell[:out_point][:index]
           },
           unlock: verify_script_json_object
         }


### PR DESCRIPTION
This is to be companioned by CKB proposal renaming https://github.com/nervosnetwork/ckb/pull/93.

Note: we don't change variable names of `contracts`. If we do, the type hash will change.

I think we would hold and merge until CKB accepts that change first.