### PR TITLE
doc: update minder.address output to be consistent with type_hash in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ If your miner balance is always 0, you might want to run the following command:
 
 ```bash
 [8] pry(main)> miner.address
-=> "0x8ce92152fd9613b80470837eb4bd46be12793662d5c22b489a63f475f2612b1d"
+=> "0x565cd9ac9a251109ff642090b91af29bfaa451b2d0e3093a29bba74743408a4a"
 ```
 
 And see if the miner address returned in your environment matches the value here, if not, it means that the mruby contract cell compiled in your environment is not exactly the same as the one we use here. In this case, please edit `type_hash` part in `/home/ubuntu/foo/bar/spec.json` with your value, and restart CKB, now miner should be able to pick up tokens mined in newer blocks.


### PR DESCRIPTION
(sorry but missing 'consistent' form the commit message)