### PR TITLE
refactor: rename outpoint to out_point for local var in contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ In this newly created folder, change the file `default.json` to the following co
     },
     "miner": {
         "new_transactions_threshold": 8,
-        "type_hash": "0x565cd9ac9a251109ff642090b91af29bfaa451b2d0e3093a29bba74743408a4a",
+        "type_hash": "0xcf7294651a9e2033243b04cfd3fa35097d56b811824691a75cd29d50ac23720a",
         "rpc_url": "http://127.0.0.1:8114/",
         "poll_interval": 5,
         "max_transactions": 10000,
@@ -158,7 +158,7 @@ If your miner balance is always 0, you might want to run the following command:
 
 ```bash
 [8] pry(main)> miner.address
-=> "0x565cd9ac9a251109ff642090b91af29bfaa451b2d0e3093a29bba74743408a4a"
+=> "0xcf7294651a9e2033243b04cfd3fa35097d56b811824691a75cd29d50ac23720a"
 ```
 
 And see if the miner address returned in your environment matches the value here, if not, it means that the mruby contract cell compiled in your environment is not exactly the same as the one we use here. In this case, please edit `type_hash` part in `/home/ubuntu/foo/bar/spec.json` with your value, and restart CKB, now miner should be able to pick up tokens mined in newer blocks.

--- a/contracts/bitcoin/sighash_all_anyonecanpay.rb
+++ b/contracts/bitcoin/sighash_all_anyonecanpay.rb
@@ -16,9 +16,9 @@ end
 tx = CKB.load_tx
 sha3 = Sha3.new
 
-outpoint = CKB.load_input_out_point(0, CKB::Source::CURRENT)
-sha3.update(outpoint["hash"])
-sha3.update(outpoint["index"].to_s)
+out_point = CKB.load_input_out_point(0, CKB::Source::CURRENT)
+sha3.update(out_point["hash"])
+sha3.update(out_point["index"].to_s)
 sha3.update(CKB::CellField.new(CKB::Source::CURRENT, 0, CKB::CellField::LOCK_HASH).readall)
 tx["outputs"].each_with_index do |output, i|
   sha3.update(output["capacity"].to_s)

--- a/contracts/bitcoin/sighash_multiple_anyonecanpay.rb
+++ b/contracts/bitcoin/sighash_multiple_anyonecanpay.rb
@@ -19,9 +19,9 @@ end
 tx = CKB.load_tx
 sha3 = Sha3.new
 
-outpoint = CKB.load_input_out_point(0, CKB::Source::CURRENT)
-sha3.update(outpoint["hash"])
-sha3.update(outpoint["index"].to_s)
+out_point = CKB.load_input_out_point(0, CKB::Source::CURRENT)
+sha3.update(out_point["hash"])
+sha3.update(out_point["index"].to_s)
 sha3.update(CKB::CellField.new(CKB::Source::CURRENT, 0, CKB::CellField::LOCK_HASH).readall)
 ARGV[2].split(",").each do |output_index|
   output_index = output_index.to_i

--- a/contracts/bitcoin/sighash_none_anyonecanpay.rb
+++ b/contracts/bitcoin/sighash_none_anyonecanpay.rb
@@ -16,9 +16,9 @@ end
 tx = CKB.load_tx
 sha3 = Sha3.new
 
-outpoint = CKB.load_input_out_point(0, CKB::Source::CURRENT)
-sha3.update(outpoint["hash"])
-sha3.update(outpoint["index"].to_s)
+out_point = CKB.load_input_out_point(0, CKB::Source::CURRENT)
+sha3.update(out_point["hash"])
+sha3.update(out_point["index"].to_s)
 sha3.update(CKB::CellField.new(CKB::Source::CURRENT, 0, CKB::CellField::LOCK_HASH).readall)
 hash = sha3.final
 

--- a/contracts/bitcoin/sighash_single_anyonecanpay.rb
+++ b/contracts/bitcoin/sighash_single_anyonecanpay.rb
@@ -19,9 +19,9 @@ end
 tx = CKB.load_tx
 sha3 = Sha3.new
 
-outpoint = CKB.load_input_out_point(0, CKB::Source::CURRENT)
-sha3.update(outpoint["hash"])
-sha3.update(outpoint["index"].to_s)
+out_point = CKB.load_input_out_point(0, CKB::Source::CURRENT)
+sha3.update(out_point["hash"])
+sha3.update(out_point["index"].to_s)
 sha3.update(CKB::CellField.new(CKB::Source::CURRENT, 0, CKB::CellField::LOCK_HASH).readall)
 output_index = ARGV[2].to_i
 output = tx["outputs"][output_index]

--- a/contracts/bitcoin_unlock.rb
+++ b/contracts/bitcoin_unlock.rb
@@ -34,9 +34,9 @@ sighash_type = ARGV[2].to_i
 
 if sighash_type & SIGHASH_ANYONECANPAY != 0
   # Only hash current input
-  outpoint = CKB.load_input_out_point(0, CKB::Source::CURRENT)
-  sha3.update(outpoint["hash"])
-  sha3.update(outpoint["index"].to_s)
+  out_point = CKB.load_input_out_point(0, CKB::Source::CURRENT)
+  sha3.update(out_point["hash"])
+  sha3.update(out_point["index"].to_s)
   sha3.update(CKB::CellField.new(CKB::Source::CURRENT, 0, CKB::CellField::LOCK_HASH).readall)
 else
   # Hash all inputs

--- a/contracts/udt/unlock.rb
+++ b/contracts/udt/unlock.rb
@@ -36,9 +36,9 @@ sighash_type = ARGV[3].to_i
 
 if sighash_type & SIGHASH_ANYONECANPAY != 0
   # Only hash current input
-  outpoint = CKB.load_input_out_point(0, CKB::Source::CURRENT)
-  sha3.update(outpoint["hash"])
-  sha3.update(outpoint["index"].to_s)
+  out_point = CKB.load_input_out_point(0, CKB::Source::CURRENT)
+  sha3.update(out_point["hash"])
+  sha3.update(out_point["index"].to_s)
   sha3.update(CKB::CellField.new(CKB::Source::CURRENT, 0, CKB::CellField::LOCK_HASH).readall)
 else
   # Hash all inputs

--- a/contracts/udt/unlock_single_cell.rb
+++ b/contracts/udt/unlock_single_cell.rb
@@ -39,9 +39,9 @@ if ARGV.length >= 4
 
   if sighash_type & SIGHASH_ANYONECANPAY != 0
     # Only hash current input
-    outpoint = CKB.load_input_out_point(0, CKB::Source::CURRENT)
-    sha3.update(outpoint["hash"])
-    sha3.update(outpoint["index"].to_s)
+    out_point = CKB.load_input_out_point(0, CKB::Source::CURRENT)
+    sha3.update(out_point["hash"])
+    sha3.update(out_point["index"].to_s)
     sha3.update(CKB::CellField.new(CKB::Source::CURRENT, 0, CKB::CellField::LOCK_HASH).readall)
   else
     # Hash all inputs


### PR DESCRIPTION
Note this will affect type hash.

@xxuejie Do we need to build a new binary before we know the new miner type hash?