### PR TITLE
doc: fix ruby-bitcoin-secp256k1 link and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $ bundle exec pry -r ./lib/ckb/wallet.rb
 [1] pry(main)>
 ```
 
-Please be noted that the SDK depends on the [bitcoin-secp256k1](https://github.com/cryptape/ruby-bitcoin-secp256k1) gem, which requires manual install of secp256k1 library. Follow the [prerequiste](https://github.com/cryptape/ruby-bitcoin-secp256k1#prerequiste) part in the gem to install secp256k1 library locally.
+Please be noted that the SDK depends on the [bitcoin-secp256k1](https://github.com/cryptape/ruby-bitcoin-secp256k1) gem, which requires manual install of secp256k1 library. Follow the [prerequisite](https://github.com/cryptape/ruby-bitcoin-secp256k1#prerequisite) part in the gem to install secp256k1 library locally.
 
 In the Ruby shell, we can start playing with the SDK.
 


### PR DESCRIPTION
The typo on ruby-bitcoin-secp256k1 has been fixed.