### PR TITLE
chore: rename always_success_script_out_point

### DIFF
--- a/lib/ckb/always_success_wallet.rb
+++ b/lib/ckb/always_success_wallet.rb
@@ -29,7 +29,7 @@ module Ckb
       end
       tx = {
         version: 0,
-        deps: [api.always_success_script_out_point],
+        deps: [api.always_success_out_point],
         inputs: i.inputs,
         outputs: outputs
       }
@@ -60,7 +60,7 @@ module Ckb
 
       tx = {
         version: 0,
-        deps: [api.always_success_script_out_point],
+        deps: [api.always_success_out_point],
         inputs: i.inputs,
         outputs: outputs
       }

--- a/lib/ckb/api.rb
+++ b/lib/ckb/api.rb
@@ -36,7 +36,7 @@ module Ckb
     end
 
     # Returns a default secp256k1-sha3 input unlock contract included in CKB
-    def always_success_script_out_point
+    def always_success_out_point
       {
         hash: genesis_block[:commit_transactions][0][:hash],
         index: 0


### PR DESCRIPTION
Rename always_success_script_out_point to always_success_out_point.