### PR TITLE
Require Ruby 2.4+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby ">= 2.4.0"
+
 gem "sha3"
 gem "bitcoin-secp256k1", "~> 0.5.0"
 gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,5 +19,8 @@ DEPENDENCIES
   pry
   sha3
 
+RUBY VERSION
+   ruby 2.6.0p0
+
 BUNDLED WITH
    1.17.2

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ You will also need [mruby-contracts](https://github.com/nervosnetwork/mruby-cont
 
 If you don't want to build mruby-contracts yourself, we have a prebuilt binary at [here](https://github.com/nervosnetwork/binary/raw/master/contracts/mruby/argv_source_entry).
 
+Finally you will need Ruby 2.4+ to run this SDK.
+
 ## Configure CKB
 
 First, follow the [README](https://github.com/nervosnetwork/ckb/blob/develop/README.md) steps to make sure CKB is up and running.


### PR DESCRIPTION
BREAKING CHANGE: this SDK will only run under Ruby 2.4.0 or above.