### PR TITLE
chore: replace unpack1 with unpack[0]

### DIFF
--- a/lib/ckb/utils.rb
+++ b/lib/ckb/utils.rb
@@ -13,7 +13,7 @@ module Ckb
     end
 
     def self.bin_to_hex(s)
-      s.unpack1("H*")
+      s.unpack("H*")[0]
     end
 
     def self.bin_to_prefix_hex(s)


### PR DESCRIPTION
1. replace `unpack1("H*")` with `unpack("H*")[0]`
2. update script to latest master version, this also replace `unpack1` method

see more info in #48 