### PR TITLE
RC v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.6.0](https://github.com/nervosnetwork/ckb-demo-ruby-sdk/compare/v0.5.0...rc/v0.6.0) (2019-02-15)
+
+### Features
+
+* add support for ruby 2.3 ([d560d5b](https://github.com/nervosnetwork/ckb-demo-ruby-sdk/commit/d560d5b))
+
+
 # [v0.5.0](https://github.com/nervosnetwork/ckb-demo-ruby-sdk/compare/v0.4.0...rc/v0.5.0) (2019-02-11)
 
 ### Bug Fixes

--- a/lib/ckb/utils.rb
+++ b/lib/ckb/utils.rb
@@ -13,7 +13,7 @@ module Ckb
     end
 
     def self.bin_to_hex(s)
-      s.unpack1("H*")
+      s.unpack("H*")[0]
     end
 
     def self.bin_to_prefix_hex(s)


### PR DESCRIPTION
### Features

 * add support for ruby 2.3 ([d560d5b](https://github.com/nervosnetwork/ckb-demo-ruby-sdk/commit/d560d5b))