### PR TITLE
docs: add params delay options to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ To change to Dummy POW mode, which merely sleeps randomly for a few seconds befo
 ```toml
 [pow]
 func = "Dummy"
+
+# Delay offset (in milliseconds)
+[pow.params.delay]
+type = "constant"
+value = 5000
 ```
 
 Then delete `[pow.params]`


### PR DESCRIPTION
CKB still throw an error if missing `pow.params`